### PR TITLE
set json logging depth to 5

### DIFF
--- a/chillog.js
+++ b/chillog.js
@@ -60,9 +60,9 @@ chillog.prototype.log = function(shortMsg, fullMsg, additionalFields) {
 chillog.prototype._log = function(shortMsg, fullMsg, additionalFields, level) {
   var message = this._format(shortMsg, fullMsg, additionalFields, level);
   if (level <= this.level.NOTICE) {
-    process.stderr.write(util.format(message) + '\n');
+    process.stderr.write(util.inspect(message, { depth: 5, colors: false }) + '\n');
   } else {
-    process.stdout.write(util.format(message) + '\n');
+    process.stdout.write(util.inspect(message, { depth: 5, colors: false }) + '\n');
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-chillog",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Gelf log formatter for nodeJS and print out to console.",
   "main": "chillog.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -58,7 +58,19 @@ describe('Chillog', function(done){
     var chillog = new Chillog({
       hostname: "test"
     });
-    var message = chillog._format("short", { data: "data" }, undefined, chillog.level.ALERT);
+    var nested = {
+      data: "data",
+      one: {
+        two: {
+          three: {
+            four: {
+              message: "deep"
+            }
+          }
+        }
+      }
+    }
+    var message = chillog._format("short", nested, undefined, chillog.level.ALERT);
     expect(message.short_message).to.equal("short");
     expect(message.full_message).to.equal("short");
     expect(message._data).to.equal("data");
@@ -264,18 +276,27 @@ describe('Chillog', function(done){
   it('should be able to print to stdout in LOG log and not stderr', function(){
     var chillog = new Chillog();
 
-    var data = {
-      id: 'test'
-    };
+    var nested = {
+      data: "data",
+      one: {
+        two: {
+          three: {
+            four: {
+              message: "deep"
+            }
+          }
+        }
+      }
+    }
 
     var output = stdout.inspectSync(function(){
-      chillog.log("short", "full", data);
+      chillog.log("short", "full", nested);
 
     });
     expect(output.length).to.equal(1);
 
     output = stderr.inspectSync(function(){
-      chillog.log("short", "full", data);
+      chillog.log("short", "full", nested);
     });
     expect(output.length).to.equal(0);
   });


### PR DESCRIPTION
Set json loggin depth to 5 for clearer logging body.

Previously:
`{
      "data": "data",
      "one": {
        "two": {
          "three": [Object]
        }
      }
    }`

Current PR:
`{
      "data": "data",
      "one": {
        "two": {
          "three": {
            "four": {
              "message": "deep"
            }
          }
        }
      }
    }`
